### PR TITLE
Fix stompy.py version

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,2 +1,3 @@
-stomp.py>=4.0.10
+stomp.py==4.1.19
+pycrypto
 six

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import sys
 import setuptools
 from setuptools.command import test
 
-REQ = {'stomp.py>=4.0.10', 'six' }
+REQ = {'stomp.py==4.1.19', 'six', 'pycrypto'}
 TREQ = {
     'mock',
     'jinja2',


### PR DESCRIPTION
Fix `stomp.py` dependency, version 4.1.20 or latter causes the following error:

`AttributeError: 'CurrentHostPortListener' object has no attribute 'current_port'`

The fix was to downgrade `stomp.py` version to 4.1.19 on the project requirements.